### PR TITLE
Add performance redesign roadmap

### DIFF
--- a/redesign/00_audit_findings.md
+++ b/redesign/00_audit_findings.md
@@ -1,0 +1,42 @@
+# Audit Findings
+
+This file summarizes the code audit that motivates the roadmap.
+
+## Working shape
+
+- `searchclient_cpp/src/searchclient.cpp` reads one level, constructs `CBS`, solves, and streams actions to `server.jar`.
+- `CBS` groups agents and boxes by color, then plans each color group as one low-level problem.
+- `Graphsearch` runs best-first search over `LowLevelState`.
+- `LowLevelState` stores agents, box bulks, parent pointer, and actions, then expands by enumerating joint action permutations.
+
+## Main risks
+
+| Area | Finding | Why it matters |
+| --- | --- | --- |
+| Tests | `test_level.cpp` and `test_state.cpp` target older APIs; `test_foo.cpp` is a placeholder. | Performance work needs a reliable red/green signal. |
+| Benchmarks | Benchmark strategies are passed to the executable, but the executable ignores `argv`. | Comparisons across strategies are currently misleading. |
+| Branching | Joint action generation creates `29^n` action tuples for a group. | This dominates runtime and memory for multi-agent color groups. |
+| Conflict detection | Box conflicts can be skipped when no responsible moving agent is found. | The planner can accept invalid plans or fail to resolve real conflicts. |
+| Ownership | CBS and graph search use raw pointers for nodes, states, frontiers, and searches. | Lifetime is unclear, and leaks can hide algorithmic performance issues. |
+| State layout | Agents and boxes are object-heavy AoS structures copied into many search states. | State expansion, hashing, and occupancy checks are more expensive than needed. |
+| Constraints | Constraints are only `(cell, time)` and apply to all agents in a group. | Replanning can over-constrain same-color groups. |
+| Heuristic | The current heuristic is Manhattan-heavy and uses the first agent for box distance. | It gives weak guidance on box-heavy levels. |
+
+## High-value source hotspots
+
+- `searchclient_cpp/include/low_level_state.hpp`: state layout, occupancy checks, joint expansion, action application.
+- `searchclient_cpp/src/cbs.cpp`: high-level CBS loop, CT node lifecycle, plan merging, conflict detection.
+- `searchclient_cpp/include/graphsearch.hpp`: low-level loop, duplicate detection, constraint filtering.
+- `searchclient_cpp/include/heuristic.hpp`: heuristic quality and repeated per-comparison work.
+- `benchmarks/run_benchmarks.py`: benchmark contract and strategy wiring.
+- `searchclient_cpp/tests/`: stale test signal.
+
+## Design conclusion
+
+The fastest path is not to polish optimal CBS. The faster path is:
+
+1. measure the current solver honestly
+2. remove obvious waste and broken signals
+3. build a compact SoA state core
+4. swap in non-optimal planners that prioritize solve rate
+5. keep only the ideas that improve warmup and comp results

--- a/redesign/01_baseline_and_metrics.md
+++ b/redesign/01_baseline_and_metrics.md
@@ -1,0 +1,63 @@
+# Baseline and Metrics
+
+Raw performance work needs a stable scoreboard before any redesign starts. The code should optimize for solve rate first, then runtime, generated states, and memory.
+
+## Benchmark scope
+
+Use two suites:
+
+1. `warmup_smoke`: small levels that should solve quickly and catch regressions.
+2. `comp_probe`: a curated subset of competition levels, including unsolved or currently hard cases.
+
+Do not require all `comp` levels to solve at first. A failed level is still useful if the run records timeout, generated state count, peak memory, and failure reason.
+
+## Primary metrics
+
+| Metric | Why it matters |
+| --- | --- |
+| solved | Primary objective. |
+| timeout | Distinguishes hard failures from planner bugs. |
+| wall_time_ms | User-visible throughput. |
+| generated_states | Measures branching pressure. |
+| expanded_states | Measures real search work. |
+| peak_rss_mb | Captures state explosion and ownership problems. |
+| actions_used | Useful quality signal, but secondary to solved/time. |
+| failure_reason | Separates timeout, memory cap, empty frontier, parser error, and invalid action. |
+
+## Benchmark command shape
+
+The benchmark runner should eventually support:
+
+- `--suite warmup_smoke`
+- `--suite comp_probe`
+- `--timeout-s N`
+- `--runs N`
+- `--jobs N`
+- `--release`
+- `--planner NAME`
+- `--output FILE`
+
+The current runner can stay as the starting point, but the first redesign task should make its strategy/planner parameter real or remove that dimension until it is implemented.
+
+## Baseline table format
+
+Each row should be one `(level, planner, run)` result:
+
+| level | planner | solved | timeout | wall_time_ms | generated | expanded | peak_rss_mb | actions | failure_reason |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+
+The summary should include:
+
+- solved count by suite
+- median wall time on solved levels
+- timeout count
+- memory-cap count
+- top 10 levels by generated states
+- top 10 levels by peak RSS
+
+## Implementation notes
+
+- Add a tiny server smoke test before running full benchmarks.
+- Prefer release builds for benchmark numbers, but keep debug smoke tests for correctness.
+- Store benchmark metadata: git SHA, compiler, flags, planner name, feature flags, level suite, timeout, and CPU count.
+- Use single-run numbers for quick iteration; use multi-run medians only when comparing competing designs.

--- a/redesign/02_fast_fixes.md
+++ b/redesign/02_fast_fixes.md
@@ -1,0 +1,49 @@
+# Fast Fixes and Local Optimizations
+
+These tasks keep the current architecture mostly intact. They are useful because they improve signal, reduce obvious waste, and make later redesign work easier to judge.
+
+## P0: restore correctness signal
+
+1. Rewrite stale tests around the current `Level`, `StaticLevel`, `LowLevelState`, and `CBS` APIs.
+2. Delete placeholder tests that only print success.
+3. Make the `make test` loop fail immediately when a test executable fails.
+4. Add one integration test that builds the client and solves a tiny warmup level through `server.jar`.
+5. Add a benchmark smoke command that runs one known-solvable warmup level.
+
+## P1: remove benchmark drift
+
+1. Either wire command-line planner selection into `searchclient` or remove `strategy` from benchmark configs.
+2. Make the benchmark output schema match the client/server metrics.
+3. Treat unknown baselines and `999` placeholders as `unsolved`, not as real comparison data.
+4. Add a small checked-in benchmark suite definition instead of requiring a local-only `benchmarks.json`.
+
+## P2: patch obvious correctness bugs
+
+1. Fix box-agent conflict attribution when a moving agent collides with a stationary box.
+2. Fail loudly in debug builds when conflict detection cannot attribute a box conflict.
+3. Add an empty-plan guard in plan merging.
+4. Validate same-group joint actions after all individual applicability checks:
+   - no two agents end in the same cell
+   - no illegal swaps
+   - no two agents manipulate the same box
+   - no box-box collisions after the joint action
+
+## P3: local hot-path optimizations
+
+1. Use content hash lookup for explored states when constraints are empty.
+2. Make frontier membership content-based rather than pointer-based.
+3. Cache heuristic values per generated state.
+4. Index boxes by cell for `getBoxAt`, `moveBox`, and conflict simulation.
+5. Replace repeated full plan copies with indexed access and NoOp fallback.
+6. Precompute constraints by timestep for each low-level replan.
+7. Record box movers while simulating a timestep instead of rescanning actions for every conflict.
+
+## P4: low-risk memory cleanup
+
+1. Make CT node ownership explicit.
+2. Ensure popped CT nodes are freed after expansion.
+3. Ensure graph search clears explored states between replans.
+4. Keep parent chains alive only for states that can still produce a plan.
+5. Add peak memory metrics before changing allocator strategy.
+
+These fixes are not the final architecture. Their value is that they make the current planner less noisy and provide a fair baseline for the redesign.

--- a/redesign/03_data_oriented_core.md
+++ b/redesign/03_data_oriented_core.md
@@ -1,0 +1,116 @@
+# Data-Oriented Core
+
+The current model stores agents, box bulks, and states as nested objects and vectors. That is convenient for iteration, but expensive for search. The redesign should use compact, explicit state data and keep domain metadata separate from mutable search state.
+
+## Design goals
+
+- Make state copies small and predictable.
+- Make hashing and equality fast.
+- Make occupancy queries O(1).
+- Avoid per-child heap allocation where possible.
+- Keep ownership obvious through arenas, handles, and value buffers.
+- Support several planner experiments without rewriting parsing or server output.
+
+## Proposed split
+
+### Static domain
+
+Immutable after parsing:
+
+- grid width and height
+- wall bitset
+- cell indexing helpers
+- agent symbols and colors
+- box symbols and colors
+- goal cells by entity type
+- precomputed distances or reachability maps
+- level decomposition data
+
+### Dynamic state
+
+Mutable per search node:
+
+- agent positions as dense arrays
+- box positions as dense arrays
+- occupancy arrays or sparse stamps
+- parent node handle
+- action taken from parent
+- g cost
+- cached hash
+- cached heuristic
+
+## SoA sketch
+
+Instead of:
+
+- `vector<Agent>`
+- `vector<BoxBulk>`
+- each object holding positions/goals/symbols
+
+Use:
+
+- `agent_cell[agent_id]`
+- `agent_color[agent_id]`
+- `agent_goal_range[agent_id]`
+- `box_cell[box_id]`
+- `box_symbol[box_id]`
+- `box_color[box_id]`
+- `box_goal_range[box_id]`
+- `cell_agent[cell]` or stamped occupancy
+- `cell_box[cell]` or stamped occupancy
+
+Symbols and colors belong to static metadata. Positions belong to dynamic state.
+
+## State identity
+
+Use a compact canonical state key:
+
+- agent cells in fixed agent order
+- box cells in fixed box identity order
+- optional timestep for temporal constraints
+
+For indistinguishable boxes of the same symbol/color, choose one strategy:
+
+1. Give every parsed box a stable identity. This is faster and simpler.
+2. Canonicalize boxes within a symbol group by sorted cell order. This can reduce duplicates but costs sorting or incremental maintenance.
+
+For raw performance, start with stable identity and measure.
+
+## Memory ownership
+
+Use explicit stores:
+
+- `NodeArena` owns all generated nodes for one low-level search.
+- `CtNodeStore` owns high-level nodes.
+- frontiers store node handles, not owning raw pointers.
+- parent links are handles into the owning arena.
+- plans are reconstructed from handles only when needed.
+
+This keeps leaks from controlling the design without making every state a separate smart pointer allocation.
+
+## Occupancy strategy
+
+Prefer fixed-size arrays indexed by cell:
+
+- `int16_t agent_at[cell_count]`
+- `int16_t box_at[cell_count]`
+- `uint32_t stamp[cell_count]` for temporary per-expansion marks
+
+For very small levels, dense arrays are simpler and likely faster than hash maps. For large sparse levels, keep the same API and swap implementation later if profiling proves it necessary.
+
+## Incremental migration path
+
+1. Introduce `LevelStaticData` and `StateView` beside current classes.
+2. Add conversion from current `Level` to the new static/dynamic representation.
+3. Port hashing, occupancy, and action application to the new representation.
+4. Keep existing server output and parser unchanged.
+5. Port low-level expansion to use handles and arrays.
+6. Delete the old object-heavy state path after benchmarks match or improve.
+
+## Performance bets
+
+- Fewer allocations during expansion.
+- Faster `getBoxAt` and `isCellFree`.
+- Cheaper equality and hashing.
+- Smaller parent chains.
+- Easier SIMD/cache-friendly scans later.

--- a/redesign/04_planner_redesign.md
+++ b/redesign/04_planner_redesign.md
@@ -1,0 +1,123 @@
+# Planner Redesign
+
+The redesign does not need optimality guarantees. That frees the planner to use bounded, greedy, prioritized, and decomposition-based techniques that solve more levels under fixed time.
+
+## Current bottleneck
+
+The current planner groups agents by color, then generates the Cartesian product of all 29 actions for every agent in that group. This is the wrong scaling shape for raw performance. The redesign should avoid full joint enumeration unless a small group truly needs it.
+
+## Candidate planner direction
+
+Use a hybrid planner:
+
+1. Preprocess the level.
+2. Assign boxes/goals/agents greedily or with min-cost matching.
+3. Plan agents with a reservation table.
+4. Escalate only local conflicts to small coupled groups.
+5. Replan failed windows rather than restarting all CBS search.
+
+This favors solve rate over proof of optimality.
+
+## Stage A: targeted successors
+
+Replace full joint tuples with targeted action generation:
+
+- generate legal actions per agent
+- prioritize actions that move toward assigned work
+- include NoOp only when useful
+- reject local collisions before creating child nodes
+- branch one active agent or one small group at a time
+
+This can be implemented before replacing the whole high-level planner.
+
+## Stage B: dynamic grouping
+
+Start with agents independent or in very small groups. Merge only when repeated conflicts prove coupling is necessary.
+
+Possible grouping signals:
+
+- same narrow corridor
+- same box or goal region
+- repeated reservation-table collisions
+- same connected component after static obstacle preprocessing
+- one agent must move a blocker for another
+
+This is the opposite of the current color-first merge. Color remains a constraint for box manipulation, not necessarily the search grouping key.
+
+## Stage C: reservation-table planning
+
+Maintain reservations over `(cell, time)` and optionally `(edge, time)`:
+
+- agent occupancy
+- box occupancy
+- pushed/pulled box paths
+- temporary blocked cells for corridors
+
+Plan agents/box tasks in priority order. If a lower-priority plan fails, use local repair or reprioritization.
+
+This will not be complete, but it is fast and can solve many levels quickly.
+
+## Stage D: box-task planning
+
+Treat box movement as the central task:
+
+1. choose an agent for a box-goal pair
+2. move the agent near the box
+3. generate a push/pull route for the box
+4. reserve agent and box trajectories
+5. repair conflicts locally
+
+Heuristics should include:
+
+- agent-to-box distance
+- box-to-goal distance
+- wall-aware distances
+- corridor penalties
+- number of blocking boxes
+- estimated pushes/pulls
+
+## Stage E: bounded best-first search
+
+Where CBS remains useful, make it intentionally suboptimal:
+
+- weighted A*
+- ECBS-style focal search
+- conflict count tie-breakers
+- time-budgeted search
+- restart with different priorities
+- stop when first valid solution is found
+
+Quality can be improved after solve rate improves.
+
+## Stage F: decomposition
+
+Use level structure:
+
+- connected components
+- rooms and corridors
+- articulation points
+- goal regions
+- boxes that never matter for active goals
+
+Solve independent regions separately when possible. For dependent regions, solve the hardest bottleneck first and reserve its corridor windows.
+
+## Stage G: fallback strategies
+
+Keep several planners behind one interface:
+
+- greedy prioritized planner
+- dynamic-group repair planner
+- weighted CBS fallback
+- current CBS compatibility planner
+
+The benchmark runner should compare planners by solve rate and timeout count, not by theoretical guarantees.
+
+## Rejection criteria
+
+Delete or demote a redesign idea if it:
+
+- lowers warmup solve rate
+- increases median solved-level runtime without improving comp solve count
+- requires large API coupling to one planner
+- makes benchmark output less comparable
+- cannot explain failures with metrics

--- a/redesign/05_decision_questions.md
+++ b/redesign/05_decision_questions.md
@@ -1,0 +1,43 @@
+# Decision Questions
+
+These questions should be answered before implementation starts. They define the first concrete plan.
+
+## Benchmark questions
+
+1. Which warmup levels form the mandatory smoke suite?
+2. Which comp levels should form the first probe suite?
+3. What timeout should be used for quick iteration?
+4. Is solve rate the only ranking metric, or should action count break ties?
+5. Should benchmark output be committed for selected runs, or only the suite definitions?
+
+## Architecture questions
+
+1. Should the SoA state core be introduced beside the current classes first, or replace them directly?
+2. Should boxes get stable identities even when boxes of the same symbol are interchangeable?
+3. Should the planner store full states, deltas, or parent handles plus action records?
+4. Should static level preprocessing become mandatory before every planner run?
+5. How much legacy compatibility is worth keeping once the benchmark suite exists?
+
+## Planner questions
+
+1. Should the first redesign target be targeted successors inside current CBS, or a separate prioritized planner?
+2. Should color be used only for box compatibility, not for default search grouping?
+3. Should failed local plans trigger dynamic group merging, priority reshuffling, or both?
+4. What is the first acceptable fallback when the greedy planner fails?
+5. Should the current CBS remain as a compatibility baseline while new planners are developed?
+
+## Performance questions
+
+1. What is the maximum acceptable memory use per level?
+2. Should release builds keep `-march=native`, or should benchmark builds be portable and reproducible?
+3. Is parallel benchmark execution acceptable, or should timing comparisons run single-job?
+4. Should profiling focus first on generated state count, wall time, or peak RSS?
+5. Is a custom arena allocator acceptable once ownership is handle-based?
+
+## Recommended answers for the first milestone
+
+1. Start with benchmark and test repair, because planner redesign without a scoreboard will be hard to judge.
+2. Introduce the SoA core beside current classes, not as a direct replacement.
+3. Give boxes stable identities at first for speed and simplicity.
+4. Build targeted successors inside the current planner before a full new planner.
+5. Keep current CBS as a benchmark baseline until the new planner solves more warmup levels.

--- a/redesign/README.md
+++ b/redesign/README.md
@@ -1,0 +1,41 @@
+# Redesign Roadmap
+
+This directory captures a performance-first redesign plan for the MAvis C++ client. The goal is raw solve throughput on `levels/warmup` and `levels/comp`, not optimality guarantees.
+
+## North star
+
+- Maximize solved levels under the server timeout.
+- Keep memory ownership explicit enough that leaks and lifetime bugs do not shape algorithm choices.
+- Prefer data layouts and planner APIs that make profiling, pruning, and replacement easy.
+- Treat the current CBS implementation as a useful prototype, not as the architecture to preserve.
+
+## Current constraints
+
+- The active client is a color-grouped CBS planner: agents and boxes are grouped by color, low-level A* plans each group, and high-level CBS resolves conflicts across groups.
+- The main scalability limit is joint action branching: `29^agent_count_in_group` action tuples are generated before filtering.
+- Tests and benchmarks are not yet a trustworthy performance signal. Some tests target an older `Level` API, and benchmark strategies are passed on the command line but ignored by the client.
+- The report already identifies two important symptoms: rising memory use and rare missed box-agent conflicts.
+
+## Step-by-step roadmap
+
+| Phase | Target | What changes | Output |
+| --- | --- | --- | --- |
+| 0 | Measurement first | Build a small repeatable benchmark suite over warmup and a curated comp subset; record solve rate, timeout count, actions, generated states, expanded states, peak RSS, and wall time. | A baseline table and repeatable command. |
+| 1 | Simple fixes | Repair stale tests, make `make test` reliable, fix benchmark strategy drift, add smoke tests through `server.jar`, and patch obvious conflict misses. | Trustworthy red/green checks. |
+| 2 | Hot-path cleanup | Fix explored/frontier lookups, remove unnecessary plan copies, cache heuristic values, index boxes by cell, and prune joint actions before allocating child states. | Lower generated states and memory churn without changing the planner shape. |
+| 3 | Ownership and API cleanup | Replace raw ownership in CBS, frontier, graph search, and state pools with explicit owners; introduce stable plan, state, constraint, and metrics types. | Clear architecture boundaries and fewer lifetime questions. |
+| 4 | Data-oriented state core | Move from object-heavy AoS state copies to compact SoA arrays for agent positions, box positions, occupancy, constraints, and parent/action metadata. | Faster state expansion, cheaper hashing, and lower memory per node. |
+| 5 | Planner redesign | Replace brute-force color-group CBS with a performance-oriented planner: targeted successor generation, dynamic grouping, bounded/suboptimal search, reservation tables, decomposition, and explicit box trajectory handling. | Higher warmup/comp solve rate. |
+| 6 | Tuning loop | Profile, benchmark, and delete losing ideas quickly. Keep interfaces stable so planner experiments can be swapped without rewriting parsing/output. | Iterative performance improvement. |
+
+## Suggested document flow
+
+1. `01_baseline_and_metrics.md` defines the measurement plan.
+2. `02_fast_fixes.md` lists low-risk repairs and optimizations.
+3. `03_data_oriented_core.md` sketches the SoA architecture.
+4. `04_planner_redesign.md` proposes the non-optimal, throughput-oriented planner path.
+5. `05_decision_questions.md` lists the decisions to settle before implementation.
+
+## Initial recommendation
+
+Start with phases 0 through 2. They are small enough to validate quickly, and they will make later algorithm work measurable. Then move to phase 4 before phase 5: a clean SoA state core gives the redesign a fast substrate and avoids baking new algorithms into the current object model.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a `redesign/` documentation set for a performance-first client redesign.
- Include a top-level roadmap plus supporting docs for audit findings, benchmarks, fast fixes, SoA architecture, planner redesign, and open decisions.
- Bias the plan toward warmup/comp solve rate, raw throughput, explicit ownership, and non-optimal planner experiments.

### Validation
- `git diff --cached --check`
- `python3 - <<'PY' ...` ASCII/final-newline validation for all `redesign/*.md` files

### Notes
- Documentation-only change; no C++ build or runtime behavior changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47a17f1e-dce4-4b88-b8a6-cd1b94f1648f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47a17f1e-dce4-4b88-b8a6-cd1b94f1648f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

